### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only:[:new]
   
   def index
+    @items = Item.all.order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only:[:new]
-  
+  before_action :authenticate_user!, only: [:new]
+
   def index
     @items = Item.all.order(created_at: :desc)
   end
@@ -21,6 +21,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:image, :name, :info, :category_id, :delivery_fee_id, :prefecture_id, :product_status_id, :scheduled_delivery_id, :numericality, :price).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :name, :info, :category_id, :delivery_fee_id, :prefecture_id, :product_status_id,
+                                 :scheduled_delivery_id, :numericality, :price).merge(user_id: current_user.id)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,15 +2,15 @@ class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :user
   has_one_attached :image
- 
+
   belongs_to_active_hash :category
   belongs_to_active_hash :delivery_fee
   belongs_to_active_hash :prefecture
   belongs_to_active_hash :product_status
   belongs_to_active_hash :scheduled_delivery
 
-  validates :category_id, :delivery_fee_id, :prefecture_id, :product_status_id, :scheduled_delivery_id, numericality: { other_than: 1 } 
-
+  validates :category_id, :delivery_fee_id, :prefecture_id, :product_status_id, :scheduled_delivery_id,
+            numericality: { other_than: 1 }
 
   with_options presence: true do
     validates :image
@@ -21,7 +21,7 @@ class Item < ApplicationRecord
     validates :prefecture_id
     validates :delivery_fee_id
     validates :scheduled_delivery_id
-    validates :price, numericality: {greater_than_or_equal_to: 300,less_than_or_equal_to: 9999999}, format: { with: /\A[0-9]+\z/ }
+    validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 },
+                      format: { with: /\A[0-9]+\z/ }
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,5 +27,4 @@ class User < ApplicationRecord
     validates :last_name_k
     validates :first_name_k
   end
-
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,60 +125,60 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
+      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開 %>
+      <% @items.each do |item| %>
+        <li class='list'>
+          <%= link_to "#" do %>
+          <div class='item-img-content'>
+            <%= image_tag(item.image, class: "item-img") %>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+            <%# 商品が売れていればsold outを表示しましょう %>
+            <%# <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div> %>
+            <%# //商品が売れていればsold outを表示しましょう %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br><%= item.delivery_fee.name %></span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <% end %>
+        </li>
+      <% end %>
+      
+      <%# 商品がない場合は以下のダミー商品が表示される %>
+      <% if @items.empty? %>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+          <% end %>
+        </li>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>
+
 </div>
 <div class='purchase-btn'>
 <%= link_to(new_item_path, class: 'purchase-btn') do %>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,19 +1,18 @@
 FactoryBot.define do
   factory :item do
-    name                    {'ピカチュウ'}
-    info                    {'ぴかちゅー'}
-    category_id             {2}
-    delivery_fee_id         {2}
-    prefecture_id           {2}
-    product_status_id       {2}
-    scheduled_delivery_id   {2} 
-    price                   {500}
+    name                    { 'ピカチュウ' }
+    info                    { 'ぴかちゅー' }
+    category_id             { 2 }
+    delivery_fee_id         { 2 }
+    prefecture_id           { 2 }
+    product_status_id       { 2 }
+    scheduled_delivery_id   { 2 }
+    price                   { 500 }
 
     association             :user
-    
+
     after(:build) do |item|
       item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
     end
-
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -14,90 +14,90 @@ RSpec.describe Item, type: :model do
       end
 
       context '商品出品がうまく行かないとき' do
-        it "画像がないとき" do
+        it '画像がないとき' do
           @item.image = nil
           @item.valid?
           expect(@item.errors.full_messages).to include("Image can't be blank")
         end
-        it "商品名が空では登録できない" do
+        it '商品名が空では登録できない' do
           @item.name = nil
           @item.valid?
           expect(@item.errors.full_messages).to include("Name can't be blank")
         end
-        it "商品の説明が空では登録できない" do
+        it '商品の説明が空では登録できない' do
           @item.info = nil
           @item.valid?
           expect(@item.errors.full_messages).to include("Info can't be blank")
         end
-        it "カテゴリーの情報が空では登録できない" do
+        it 'カテゴリーの情報が空では登録できない' do
           @item.category_id = nil
           @item.valid?
           expect(@item.errors.full_messages).to include("Category can't be blank")
         end
-        it "カテゴリーの情報が---では登録できない" do
+        it 'カテゴリーの情報が---では登録できない' do
           @item.category_id = 1
           @item.valid?
-          expect(@item.errors.full_messages).to include("Category must be other than 1")
+          expect(@item.errors.full_messages).to include('Category must be other than 1')
         end
-        it "商品の状態の情報が空では登録できない" do
+        it '商品の状態の情報が空では登録できない' do
           @item.product_status_id = nil
           @item.valid?
           expect(@item.errors.full_messages).to include("Product status can't be blank")
         end
-        it "商品の状態の情報が---では登録できない" do
+        it '商品の状態の情報が---では登録できない' do
           @item.product_status_id = 1
           @item.valid?
-          expect(@item.errors.full_messages).to include("Product status must be other than 1")
+          expect(@item.errors.full_messages).to include('Product status must be other than 1')
         end
-        it "配送料の負担の情報が空では登録できない" do
+        it '配送料の負担の情報が空では登録できない' do
           @item.delivery_fee_id = nil
           @item.valid?
           expect(@item.errors.full_messages).to include("Delivery fee can't be blank")
         end
-        it "配送料の負担の情報が---では登録できない" do
+        it '配送料の負担の情報が---では登録できない' do
           @item.delivery_fee_id = 1
           @item.valid?
-          expect(@item.errors.full_messages).to include("Delivery fee must be other than 1")
+          expect(@item.errors.full_messages).to include('Delivery fee must be other than 1')
         end
-        it "発送元の地域の情報が空では登録できない" do
+        it '発送元の地域の情報が空では登録できない' do
           @item.prefecture_id = nil
           @item.valid?
           expect(@item.errors.full_messages).to include("Prefecture can't be blank")
         end
-        it "発送元の地域の情報が---では登録できない" do
+        it '発送元の地域の情報が---では登録できない' do
           @item.prefecture_id = 1
           @item.valid?
-          expect(@item.errors.full_messages).to include("Prefecture must be other than 1")
+          expect(@item.errors.full_messages).to include('Prefecture must be other than 1')
         end
-        it "発送までの日数の情報が空では登録できない" do
+        it '発送までの日数の情報が空では登録できない' do
           @item.scheduled_delivery_id = nil
           @item.valid?
           expect(@item.errors.full_messages).to include("Scheduled delivery can't be blank")
         end
-        it "発送までの日数の情報が---では登録できない" do
+        it '発送までの日数の情報が---では登録できない' do
           @item.scheduled_delivery_id = 1
           @item.valid?
-          expect(@item.errors.full_messages).to include("Scheduled delivery must be other than 1")
+          expect(@item.errors.full_messages).to include('Scheduled delivery must be other than 1')
         end
-        it "価格の情報が空では登録できない" do
+        it '価格の情報が空では登録できない' do
           @item.price = nil
           @item.valid?
           expect(@item.errors.full_messages).to include("Price can't be blank")
         end
-        it "価格が300以下では登録できない" do
+        it '価格が300以下では登録できない' do
           @item.price = 299
           @item.valid?
-          expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300")
+          expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
         end
-        it "価格が9999999以上では登録できない" do
-          @item.price = 10000000
+        it '価格が9999999以上では登録できない' do
+          @item.price = 10_000_000
           @item.valid?
-          expect(@item.errors.full_messages).to include("Price must be less than or equal to 9999999")
+          expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
         end
-        it "価格が半角数字以外では登録できない" do
+        it '価格が半角数字以外では登録できない' do
           @item.price = '２２２２'
           @item.valid?
-          expect(@item.errors.full_messages).to include("Price is not a number")
+          expect(@item.errors.full_messages).to include('Price is not a number')
         end
       end
     end


### PR DESCRIPTION
#what
商品一覧表示機能

#why
登録された商品を表示させるため

 画像が表示されており、画像がリンク切れなどになっていないこと出品した商品の一覧表示ができていること
上から、出品された日時が新しい順に表示されること
「画像/価格/商品名」の3つの情報について表示できていること
https://gyazo.com/09b9640fd3c849e311e4590f79f47d08

ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
https://gyazo.com/cfbc4e00a5d8b4a8f0a4a2ceb8165d6e

売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
→未実装
